### PR TITLE
VivoSoC3: added freq API and fll support in kernel

### DIFF
--- a/include/rt/rt_freq.h
+++ b/include/rt/rt_freq.h
@@ -37,6 +37,14 @@
 #define __RT_FREQ_DOMAIN_PERIPH 1
 #define RT_FREQ_NB_DOMAIN 3
 
+#elif PULP_CHIP == CHIP_VIVOSOC3
+
+#define __RT_FREQ_DOMAIN_FC       1   // soc domain, soc fll
+#define __RT_FREQ_DOMAIN_CL       0   // cluster domain, soc fll or cl fll
+#define __RT_FREQ_DOMAIN_PERIPH   2   // periph domain, soc fll or per fll
+#define __RT_FREQ_DOMAIN_PM       3   // pm domain, soc fll
+#define RT_FREQ_NB_DOMAIN         4 
+
 #else
 
 #define __RT_FREQ_DOMAIN_FC 0
@@ -50,7 +58,6 @@
 
 /// @endcond
 
-
 /**        
  * @ingroup groupKernel        
  */
@@ -60,8 +67,6 @@
  * 
  */
 
-
-
 /**        
  * @addtogroup Freq
  * @{        
@@ -70,7 +75,90 @@
 /**@{*/
 
 
+#if PULP_CHIP == CHIP_VIVOSOC3
 
+/** \enum rt_freq_domain_e
+ * \brief Frequency domains.
+ *
+ * Describes a frequency domain.
+ */
+typedef enum {
+  RT_FREQ_DOMAIN_FC     = __RT_FREQ_DOMAIN_FC,     /*!< Frequency domain for fabric controller. */
+  RT_FREQ_DOMAIN_CL     = __RT_FREQ_DOMAIN_CL,     /*!< Frequency domain for cluster 0. Other cluster domains can be obtained by adding the cluster ID to this constant. */  
+  RT_FREQ_DOMAIN_PERIPH = __RT_FREQ_DOMAIN_PERIPH, /*!< Frequency domain for peripherals with secondary udma clk */ 
+  RT_FREQ_DOMAIN_PM     = __RT_FREQ_DOMAIN_PM,     /*!< Frequency domain for power manager. */
+} rt_freq_domain_e;
+
+/** \brief Get current frequency of a domain.
+ *
+ * Gets the current frequency of a specific frequency domain in Hz. 
+ * 
+ * \param     domain The frequency domain.
+ * \return           The frequency in Hz.
+ */
+static inline unsigned int rt_freq_get(rt_freq_domain_e domain);
+
+/** \brief Get current config of a domain.
+ *
+ * Gets the current clock tree configuration of a specific frequency domain. 
+ * 
+ * \param     domain The frequency domain.
+ * \return           The clock tree configuration.
+ */
+static inline hal_freq_domain_clk_tree_config_e rt_freq_config_get(rt_freq_domain_e domain);
+
+/** \brief Get current config of a domain.
+ *
+ * Gets the current clock tree configuration of a specific frequency domain. 
+ * 
+ * \param     domain The frequency domain.
+ * \param     config The clock tree configuration.
+ * \return           0 if success, -1 otherwise.
+ */
+extern int rt_freq_config_set(rt_freq_domain_e domain, hal_freq_domain_clk_tree_config_e config);
+
+/** \brief Get frequency of a set of a given FLL. 
+ *
+ * Gets the frequency of the given set of a specific FLL in Hz. 
+ * 
+ * \param     fll    The FLL.
+ * \param     set    The set of the FLL.
+ * \return           The frequency in Hz.
+ */
+extern unsigned int rt_freq_fll_freq_get(hal_fll_e fll, hal_fll_reg_set_e set);
+
+/** \brief Set frequency of a set of a given FLL. 
+ *
+ * Gets the frequency of the given set of a specific FLL in Hz. 
+ * 
+ * \param     fll    The FLL.
+ * \param     set    The set of the FLL.
+ * \param     freq   The frequency in Hz.
+ * \return           The frequency that was set in Hz.
+ */
+extern unsigned int rt_freq_fll_freq_set(hal_fll_e fll, hal_fll_reg_set_e set, unsigned int freq);
+
+/** \brief Get status of a set of a given FLL. 
+ *
+ * Gets the status of the given set of a specific FLL in Hz. 
+ * 
+ * \param     fll    The FLL.
+ * \return           0 if set 0 active, 1 if set 1 active, -1 if FLL disabled.
+ */
+extern int rt_freq_fll_status_get(hal_fll_e fll);
+
+/** \brief Set frequency of a set of a given FLL. 
+ *
+ * Gets the frequency of the given set of a specific FLL in Hz. 
+ * 
+ * \param     fll    The FLL.
+ * \param     set    The set of the FLL.
+ * \param     enable 0: disable the FLL, 1: enable the FLL.
+ * \return           0 if success, -1 otherwise.
+ */
+extern int rt_freq_fll_status_set(hal_fll_e fll, hal_fll_reg_set_e set, unsigned char enable);
+
+#else
 /** \enum rt_freq_domain_e
  * \brief Frequency domains.
  *
@@ -81,8 +169,6 @@ typedef enum {
   RT_FREQ_DOMAIN_CL     = __RT_FREQ_DOMAIN_CL,     /*!< Frequency domain for cluster 0. Other cluster domains can be obtained by adding the cluster ID to this constant. */  
   RT_FREQ_DOMAIN_PERIPH = __RT_FREQ_DOMAIN_PERIPH,
 } rt_freq_domain_e;
-
-
 
 /** \brief Get current frequency of a domain.
  *
@@ -106,6 +192,7 @@ static inline int rt_freq_get(rt_freq_domain_e domain);
  */
 static inline int rt_freq_set(rt_freq_domain_e domain, unsigned int freq);
 
+#endif
 
 //!@}
 
@@ -113,112 +200,149 @@ static inline int rt_freq_set(rt_freq_domain_e domain, unsigned int freq);
  * @}
  */
 
-
 /// @cond IMPLEM
 
-#if PULP_CHIP == CHIP_QUENTIN || PULP_CHIP == CHIP_KERBIN || PULP_CHIP == CHIP_PULP || PULP_CHIP == CHIP_ARNOLD
-#define __RT_FLL_CL 2
-#define __RT_FLL_PERIPH 1
-#define __RT_FLL_FC 0
-#else
-#define __RT_FLL_FC     0
-#define __RT_FLL_PERIPH 0
-#define __RT_FLL_CL     1
-#endif
-
-int rt_freq_set_and_get(rt_freq_domain_e domain, unsigned int freq, unsigned int *out_freq);
-
-extern int __rt_freq_domains[];
-extern int __rt_freq_next_domains[];
-
-static inline int rt_freq_set(rt_freq_domain_e domain, unsigned int freq)
-{
-  return rt_freq_set_and_get(domain, freq, NULL);
-}
-
-static inline void __rt_freq_set_value(rt_freq_domain_e domain, unsigned int freq)
-{
-  __rt_freq_domains[domain] = freq;
-}
-
-#if defined(FLL_VERSION)
-
-static inline int rt_freq_get(rt_freq_domain_e domain)
-{
-  return __rt_freq_domains[domain];
-}
-
-static inline int rt_freq_get_next(rt_freq_domain_e domain)
-{
-  return __rt_freq_next_domains[domain];
-}
-
-#else
-
-static inline int rt_freq_get(rt_freq_domain_e domain)
-{
-#if PULP_CHIP_FAMILY == CHIP_USOC_V1
-  return 60000000;
-#else
-#if PULP_CHIP_FAMILY == CHIP_VIVOSOC2
-  return 100000000;
-#else
-  return 50000000;
-#endif
-#endif
-}
-
-static inline int rt_freq_get_next(rt_freq_domain_e domain)
-{
-#if PULP_CHIP_FAMILY == CHIP_VIVOSOC2
-  return 100000000;
-#else
-  return 50000000;
-#endif
-}
-
-#endif
-
-void rt_freq_wait_convergence(int fll);
-
-int __rt_freq_set_constraint_multiple(unsigned int freq);
-
-void __rt_freq_remove_constraint_multiple(unsigned int freq);
-
-unsigned int __rt_fll_set_freq(int fll, unsigned int frequency);
-
-unsigned int __rt_fll_init(int fll);
-
-void __rt_fll_deinit(int fll);
-
-void __rt_freq_init();
-
-void __rt_flls_constructor();
-
-extern int __rt_fll_freq[];
-
-static inline unsigned int __rt_fll_freq_get(int fll)
-{
-  return __rt_fll_freq[fll];
-}
-
-static inline unsigned int __rt_freq_periph_get()
-{
-#if PULP_CHIP_FAMILY == CHIP_USOC_V1
-  return 50000000;
-#else
 #if PULP_CHIP == CHIP_VIVOSOC3
-  return 10000000;
-#else
-  return rt_freq_get(RT_FREQ_DOMAIN_PERIPH);
-#endif
-#endif
-}
 
-static inline unsigned int __rt_freq_periph_get_next()
-{
-  return rt_freq_get_next(RT_FREQ_DOMAIN_PERIPH);
-}
+  typedef struct __rt_freq_domain_settings_s {   
+    unsigned int __rt_freq_domain_freq;
+    hal_freq_domain_clk_tree_config_e __rt_freq_domain_config;
+    char __rt_freq_domain_fll_on;
+    char __rt_freq_domain_alt_fll_on;
+  } __rt_freq_domain_settings_t;
+
+  extern __rt_freq_domain_settings_t __rt_freq_domain_settings[];  
+
+  // fll helper functions
+  void __rt_freq_init(void);  
+  void __rt_flls_constructor(void);
+  void __rt_fll_set_init(hal_fll_e fll);
+  void __rt_fll_disable(hal_fll_e fll);
+  unsigned int __rt_fll_active_freq_get(hal_fll_e fll);
+  unsigned int __rt_fll_set_freq_get(hal_fll_e fll, hal_fll_reg_set_e set);
+  unsigned int __rt_fll_set_freq_set(hal_fll_e fll, hal_fll_reg_set_e set, unsigned int frequency);
+  hal_fll_reg_set_e __rt_fll_set_active_get(hal_fll_e fll);
+  unsigned int __rt_fll_set_active_set(hal_fll_e fll, hal_fll_reg_set_e set);
+  unsigned int __rt_fll_enable(hal_fll_e fll);
+  void __rt_fll_disable(hal_fll_e fll);
+
+  static inline unsigned int rt_freq_get(rt_freq_domain_e domain) 
+  {
+    return __rt_freq_domain_settings[domain].__rt_freq_domain_freq; // freq in Hz
+  }
+
+  static inline hal_freq_domain_clk_tree_config_e rt_freq_config_get(rt_freq_domain_e domain)
+  {
+    return __rt_freq_domain_settings[domain].__rt_freq_domain_config;
+  }  
+
+  static inline unsigned int __rt_freq_periph_get()
+  {
+    return rt_freq_get(RT_FREQ_DOMAIN_PERIPH);
+  }  
+   
+#else
+
+  #if PULP_CHIP == CHIP_QUENTIN || PULP_CHIP == CHIP_KERBIN || PULP_CHIP == CHIP_PULP || PULP_CHIP == CHIP_ARNOLD
+  #define __RT_FLL_CL 2
+  #define __RT_FLL_PERIPH 1
+  #define __RT_FLL_FC 0
+  #else
+  #define __RT_FLL_FC     0
+  #define __RT_FLL_PERIPH 0
+  #define __RT_FLL_CL     1
+  #endif
+
+  int rt_freq_set_and_get(rt_freq_domain_e domain, unsigned int freq, unsigned int *out_freq);
+
+  extern int __rt_freq_domains[];
+  extern int __rt_freq_next_domains[];
+
+  static inline int rt_freq_set(rt_freq_domain_e domain, unsigned int freq)
+  {
+    return rt_freq_set_and_get(domain, freq, NULL);
+  }
+
+  static inline void __rt_freq_set_value(rt_freq_domain_e domain, unsigned int freq)
+  {
+    __rt_freq_domains[domain] = freq;
+  }
+
+  #if defined(FLL_VERSION)
+
+  static inline int rt_freq_get(rt_freq_domain_e domain)
+  {
+    return __rt_freq_domains[domain];
+  }
+
+  static inline int rt_freq_get_next(rt_freq_domain_e domain)
+  {
+    return __rt_freq_next_domains[domain];
+  }
+
+  #else
+
+  static inline int rt_freq_get(rt_freq_domain_e domain)
+  {
+  #if PULP_CHIP_FAMILY == CHIP_USOC_V1
+    return 60000000;
+  #else
+  #if PULP_CHIP_FAMILY == CHIP_VIVOSOC2
+    return 100000000;
+  #else
+    return 50000000;
+  #endif
+  #endif
+  }
+
+  static inline int rt_freq_get_next(rt_freq_domain_e domain)
+  {
+  #if PULP_CHIP_FAMILY == CHIP_VIVOSOC2
+    return 100000000;
+  #else
+    return 50000000;
+  #endif
+  }
+
+  #endif
+
+  void rt_freq_wait_convergence(int fll);
+
+  int __rt_freq_set_constraint_multiple(unsigned int freq);
+
+  void __rt_freq_remove_constraint_multiple(unsigned int freq);
+
+  unsigned int __rt_fll_set_freq(int fll, unsigned int frequency);
+
+  unsigned int __rt_fll_init(int fll);
+
+  void __rt_fll_deinit(int fll);
+
+  void __rt_freq_init();
+
+  void __rt_flls_constructor();
+
+  extern int __rt_fll_freq[];
+
+  static inline unsigned int __rt_fll_freq_get(int fll)
+  {
+    return __rt_fll_freq[fll];
+  }
+
+  static inline unsigned int __rt_freq_periph_get()
+  {
+  #if PULP_CHIP_FAMILY == CHIP_USOC_V1
+    return 50000000;
+  #else
+    return rt_freq_get(RT_FREQ_DOMAIN_PERIPH);
+  #endif
+  }
+
+  static inline unsigned int __rt_freq_periph_get_next()
+  {
+    return rt_freq_get_next(RT_FREQ_DOMAIN_PERIPH);
+  }
+#endif  
 
 /// @endcond
 

--- a/kernel/kernel.mk
+++ b/kernel/kernel.mk
@@ -100,6 +100,12 @@ PULP_LIB_FC_SRCS_rt += kernel/gap/maestro.c kernel/gap/pmu_driver.c
 endif
 
 
+ifeq '$(pulp_chip_family)' 'vivosoc3'
+PULP_LIB_FC_SRCS_rt     += kernel/vivosoc3/fll.c 
+PULP_LIB_FC_SRCS_rt     += kernel/vivosoc3/freq.c
+endif
+
+
 PULP_LIB_FC_SRCS_rt += kernel/cluster.c
 
 ifneq '$(perf_counters)' ''

--- a/kernel/vivosoc3/fll.c
+++ b/kernel/vivosoc3/fll.c
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2018 ETH Zurich and University of Bologna
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "rt/rt_api.h"
+
+#define __RT_FLL_REGULATION_TOL   0 // tolerance in percent of middle value
+#define __RT_FLL_CLK_GOOD_TOL     5 // tolerance in percent of middle value
+
+typedef struct __rt_fll_settings_s {   
+  unsigned int __rt_fll_freq[2];
+  char __rt_fll_active_set;
+  char __rt_fll_is_on;
+  unsigned int __rt_fll_ref;
+} __rt_fll_settings_t;
+
+__rt_fll_settings_t __rt_fll_settings[ARCHI_NB_FLL];
+
+static unsigned int __rt_fll_get_mult_from_freq(unsigned int freq, unsigned int ref, unsigned int *mult)
+{
+  unsigned int M = freq/ref;
+
+  *mult = M;
+  return ref*M;
+}
+
+static unsigned int __rt_fll_get_freq_from_mult(unsigned int mult, unsigned int ref)
+{
+  return ref*mult;
+}
+
+// set the frequency of the given set
+unsigned int __rt_fll_set_freq_set(hal_fll_e fll, hal_fll_reg_set_e set, unsigned int frequency)
+{
+  if(fll >= ARCHI_NB_FLL) return 0;
+
+  unsigned int real_freq, mult;
+  unsigned int tolerance;
+
+  real_freq = __rt_fll_get_mult_from_freq(frequency, __rt_fll_settings[fll].__rt_fll_ref, &mult);
+  rt_trace(RT_TRACE_FREQ, "Setting FLL frequency (fll: %d, freq: %d, mult: %d, real_freq: %d)\n", fll, frequency, mult, real_freq);
+
+  __rt_fll_settings[fll].__rt_fll_freq[set] = real_freq;
+
+  tolerance = (mult * __RT_FLL_REGULATION_TOL)/100;
+  hal_fll_set_regulation_set(fll,set,mult,tolerance);
+
+  tolerance = (mult * __RT_FLL_CLK_GOOD_TOL)/100;
+  hal_fll_set_clk_good_set(fll,set,mult,tolerance);
+
+  __rt_fll_settings[fll].__rt_fll_freq[set] = real_freq;
+
+  return real_freq;
+}
+
+// get the frequency of the given set
+unsigned int __rt_fll_set_freq_get(hal_fll_e fll, hal_fll_reg_set_e set)
+{
+  return __rt_fll_settings[fll].__rt_fll_freq[set];
+}
+
+// set the active set
+unsigned int __rt_fll_set_active_set(hal_fll_e fll, hal_fll_reg_set_e set)
+{
+  hal_fll_set_sel_set(fll, set);
+  __rt_fll_settings[fll].__rt_fll_active_set = set;
+  
+  return __rt_fll_settings[fll].__rt_fll_freq[(unsigned int)__rt_fll_settings[fll].__rt_fll_active_set];
+}
+
+// get the active set
+hal_fll_reg_set_e __rt_fll_set_active_get(hal_fll_e fll)
+{
+  return (hal_fll_reg_set_e) __rt_fll_settings[fll].__rt_fll_active_set;
+}
+
+// get active frequency
+unsigned int __rt_fll_active_freq_get(hal_fll_e fll)
+{
+  if(fll<ARCHI_NB_FLL) return __rt_fll_settings[fll].__rt_fll_freq[(unsigned int)__rt_fll_settings[fll].__rt_fll_active_set];
+  else return 0;
+}
+
+// init sets of fll - does not turn the FLL on!!
+void __rt_fll_set_init(hal_fll_e fll)
+{
+  rt_trace(RT_TRACE_INIT, "Initializing FLL sets (fll: %d)\n", fll);
+
+  // init FLL configs
+  __rt_fll_set_freq_set(fll,0,__rt_fll_settings[fll].__rt_fll_freq[0]);
+  __rt_fll_set_freq_set(fll,1,__rt_fll_settings[fll].__rt_fll_freq[1]);
+  __rt_fll_set_active_set(fll, __rt_fll_settings[fll].__rt_fll_active_set);  // do not do that for SOC FLL!!
+}
+
+unsigned int __rt_fll_enable(hal_fll_e fll)
+{
+  rt_trace(RT_TRACE_INIT, "Enable FLL (fll: %d)\n", fll);
+
+  hal_fll_enable_set(fll,1);
+
+  __rt_fll_settings[fll].__rt_fll_is_on = 1;
+
+  rt_trace(RT_TRACE_INIT, "FLL is locked (fll: %d, freq: %d)\n", fll, freq);
+
+  return __rt_fll_settings[fll].__rt_fll_freq[0];
+}
+
+
+void __rt_fll_disable(hal_fll_e fll)
+{
+  if (fll == HAL_FLL_SOC) return;   // currently SOC Fll is not stopped
+  else 
+  {
+    hal_fll_enable_set(fll, 0); // disable FLL
+    __rt_fll_settings[fll].__rt_fll_is_on = 0;    
+  }
+}
+
+void __rt_flls_constructor(void)
+{
+  for (int i=0; i<ARCHI_NB_FLL; i++)
+  {
+    __rt_fll_settings[i].__rt_fll_freq[0] = 10000000;
+    __rt_fll_settings[i].__rt_fll_freq[1] = 10000000;
+    __rt_fll_settings[i].__rt_fll_active_set = 0;
+    __rt_fll_settings[i].__rt_fll_is_on = 0;
+    __rt_fll_settings[i].__rt_fll_ref = ARCHI_FLL_REF_CLOCK_SLOW;
+  }
+}

--- a/kernel/vivosoc3/freq.c
+++ b/kernel/vivosoc3/freq.c
@@ -1,0 +1,279 @@
+/*
+ * Copyright (C) 2018 ETH Zurich, University of Bologna and GreenWaves Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "rt/rt_api.h"
+
+__rt_freq_domain_settings_t __rt_freq_domain_settings[RT_FREQ_NB_DOMAIN];
+
+void __rt_freq_init(void)
+{
+  // flls
+  __rt_flls_constructor();  // init fll set constructor
+
+  __rt_fll_set_init(HAL_FLL_CL);  // init fll set register
+
+  // take care here!!
+  if(hal_fll_check_ref_fast()) hal_freq_soc_clk_tree_config_set(FREQ_DOMAIN_CLK_TREE_16M); // fast reference up and running
+  else hal_freq_soc_clk_tree_config_set(FREQ_DOMAIN_CLK_TREE_32K); // take slow reference because fast is not running properly
+
+  __rt_fll_set_init(HAL_FLL_SOC);  // init fll set register
+
+  hal_freq_soc_clk_tree_config_set(FREQ_DOMAIN_CLK_TREE_FLL_SOC);  // switch back to fll_soc clock for soc_clk
+
+  __rt_fll_set_init(HAL_FLL_PER);  // init fll set register
+
+  // freq domains
+  __rt_freq_domain_settings[RT_FREQ_DOMAIN_CL].__rt_freq_domain_freq =            __rt_fll_set_freq_get(HAL_FLL_SOC, 0);
+  __rt_freq_domain_settings[RT_FREQ_DOMAIN_CL].__rt_freq_domain_config =          FREQ_DOMAIN_CLK_TREE_FLL_SOC;
+  __rt_freq_domain_settings[RT_FREQ_DOMAIN_CL].__rt_freq_domain_fll_on =          1;  // soc fll is on from beginning
+  __rt_freq_domain_settings[RT_FREQ_DOMAIN_CL].__rt_freq_domain_alt_fll_on =      0; 
+  hal_freq_soc_clk_tree_config_set(FREQ_DOMAIN_CLK_TREE_FLL_SOC);
+
+  __rt_freq_domain_settings[RT_FREQ_DOMAIN_FC].__rt_freq_domain_freq =            __rt_fll_set_freq_get(HAL_FLL_SOC, 0);
+  __rt_freq_domain_settings[RT_FREQ_DOMAIN_FC].__rt_freq_domain_config =          FREQ_DOMAIN_CLK_TREE_FLL_SOC;
+  __rt_freq_domain_settings[RT_FREQ_DOMAIN_FC].__rt_freq_domain_fll_on =          1;  // soc fll is on from beginning
+  __rt_freq_domain_settings[RT_FREQ_DOMAIN_FC].__rt_freq_domain_alt_fll_on =      -1; // there is no alternative fll available
+  hal_freq_soc_clk_tree_config_set(FREQ_DOMAIN_CLK_TREE_FLL_SOC);
+
+  __rt_freq_domain_settings[RT_FREQ_DOMAIN_PERIPH].__rt_freq_domain_freq =        __rt_fll_set_freq_get(HAL_FLL_SOC, 0);
+  __rt_freq_domain_settings[RT_FREQ_DOMAIN_PERIPH].__rt_freq_domain_config =      FREQ_DOMAIN_CLK_TREE_FLL_SOC;
+  __rt_freq_domain_settings[RT_FREQ_DOMAIN_PERIPH].__rt_freq_domain_fll_on =      1;  // soc fll is on from beginning
+  __rt_freq_domain_settings[RT_FREQ_DOMAIN_PERIPH].__rt_freq_domain_alt_fll_on =  0; 
+  hal_freq_soc_clk_tree_config_set(FREQ_DOMAIN_CLK_TREE_FLL_SOC);
+
+  __rt_freq_domain_settings[RT_FREQ_DOMAIN_PM].__rt_freq_domain_freq =            __rt_fll_set_freq_get(HAL_FLL_SOC, 0);
+  __rt_freq_domain_settings[RT_FREQ_DOMAIN_PM].__rt_freq_domain_config =          FREQ_DOMAIN_CLK_TREE_FLL_SOC;
+  __rt_freq_domain_settings[RT_FREQ_DOMAIN_PM].__rt_freq_domain_fll_on =          1;  // soc fll is on from beginning
+  __rt_freq_domain_settings[RT_FREQ_DOMAIN_PM].__rt_freq_domain_alt_fll_on =      -1; // there is no alternative fll available
+  hal_freq_soc_clk_tree_config_set(FREQ_DOMAIN_CLK_TREE_FLL_SOC);
+}
+
+int rt_freq_config_set(rt_freq_domain_e domain, hal_freq_domain_clk_tree_config_e config)
+{
+  int irq = rt_irq_disable();
+  int error = -1;
+
+  // checks and storing of configs
+  switch(config)
+  {
+    case FREQ_DOMAIN_CLK_TREE_32K:  // can always be done
+    {
+      __rt_freq_domain_settings[domain].__rt_freq_domain_config = FREQ_DOMAIN_CLK_TREE_32K;
+      __rt_freq_domain_settings[domain].__rt_freq_domain_freq = 32768;
+      break;
+    }
+    case FREQ_DOMAIN_CLK_TREE_16M:  // can only be done if 16M clk is running
+    {
+      if(hal_fll_check_ref_fast())
+      {
+        __rt_freq_domain_settings[domain].__rt_freq_domain_config = FREQ_DOMAIN_CLK_TREE_16M;
+        __rt_freq_domain_settings[domain].__rt_freq_domain_freq = 16384000;
+      }
+      else goto error;
+      break;
+    }
+    case FREQ_DOMAIN_CLK_TREE_FLL_SOC:  // can only be done if soc fll is running (should always be the case)
+    {
+      if(__rt_freq_domain_settings[domain].__rt_freq_domain_fll_on == 1)
+      {
+        __rt_freq_domain_settings[domain].__rt_freq_domain_config = FREQ_DOMAIN_CLK_TREE_FLL_SOC;
+        __rt_freq_domain_settings[domain].__rt_freq_domain_freq = __rt_fll_active_freq_get(HAL_FLL_SOC);       
+      }
+      else goto error;
+      break;
+    }
+    case FREQ_DOMAIN_CLK_TREE_FLL_ALT:  // can only be done if alternate fll is running
+    {
+      if(__rt_freq_domain_settings[domain].__rt_freq_domain_alt_fll_on == 1)
+      {
+        if(domain == RT_FREQ_DOMAIN_CL) __rt_freq_domain_settings[domain].__rt_freq_domain_freq = __rt_fll_active_freq_get(HAL_FLL_CL); 
+        else if(domain == RT_FREQ_DOMAIN_PERIPH) __rt_freq_domain_settings[domain].__rt_freq_domain_freq = __rt_fll_active_freq_get(HAL_FLL_PER); 
+        else goto error; // something went wrong
+        __rt_freq_domain_settings[domain].__rt_freq_domain_config = FREQ_DOMAIN_CLK_TREE_FLL_ALT;
+      }
+      else goto error;     
+      break;
+    }
+    default: goto error;
+  }
+
+  // change clk tree config
+  switch(domain)
+  {
+    case RT_FREQ_DOMAIN_FC:
+    {
+      hal_freq_soc_clk_tree_config_set(__rt_freq_domain_settings[domain].__rt_freq_domain_config);
+      break;
+    }
+    case RT_FREQ_DOMAIN_CL:
+    {
+      hal_freq_cl_clk_tree_config_set(__rt_freq_domain_settings[domain].__rt_freq_domain_config);
+      break;
+    }
+    case RT_FREQ_DOMAIN_PERIPH:
+    {
+      hal_freq_per_clk_tree_config_set(__rt_freq_domain_settings[domain].__rt_freq_domain_config);
+      break;
+    }
+    case RT_FREQ_DOMAIN_PM:
+    {
+      hal_freq_pm_clk_tree_config_set(__rt_freq_domain_settings[domain].__rt_freq_domain_config);
+      break;
+    }
+    default: goto error;
+  }
+
+  error = 0;
+
+error:
+  rt_irq_restore(irq);  
+  return error;
+}
+
+unsigned int rt_freq_fll_freq_get(hal_fll_e fll, hal_fll_reg_set_e set)
+{
+  int irq = rt_irq_disable();
+  int error = 0;
+
+  // checks
+  if(fll > HAL_FLL_PER) goto error;
+  if(set > HAL_FLL_REG_SET_1) goto error;
+
+  // get frequency
+  error = __rt_fll_set_freq_get(fll, set);
+
+error:
+  rt_irq_restore(irq);  
+  return error;  
+}
+
+unsigned int rt_freq_fll_freq_set(hal_fll_e fll, hal_fll_reg_set_e set, unsigned int freq)
+{
+  int irq = rt_irq_disable();
+  int error = 0;
+
+  // checks
+  if(fll > HAL_FLL_PER) goto error;
+  if(set > HAL_FLL_REG_SET_1) goto error;  
+
+  // set frequency
+  error = __rt_fll_set_freq_set(fll, set, freq);
+
+error:
+  rt_irq_restore(irq);  
+  return error;    
+}
+
+int rt_freq_fll_status_get(hal_fll_e fll)
+{
+  int irq = rt_irq_disable();
+  int error = -1;
+
+  // checks
+  if(fll > HAL_FLL_PER) goto error;
+
+  if((0x1 & hal_fll_status_get(fll)) == 0) goto error; // fll is off
+  else error = (int) __rt_fll_set_active_get(fll); 
+
+error:
+  rt_irq_restore(irq);  
+  return error;  
+}
+
+int rt_freq_fll_status_set(hal_fll_e fll, hal_fll_reg_set_e set, unsigned char enable)
+{
+
+  int irq = rt_irq_disable();
+  int error = -1;
+  unsigned int freq;
+
+  // checks
+  if(set > HAL_FLL_REG_SET_1) goto error;
+
+  // enable (has to be done first in order to enable and set set within this function)
+  if(enable)
+  {
+    freq = __rt_fll_enable(fll);
+    if(fll == HAL_FLL_CL) __rt_freq_domain_settings[RT_FREQ_DOMAIN_CL].__rt_freq_domain_alt_fll_on = 1;
+    else if(fll == HAL_FLL_PER) __rt_freq_domain_settings[RT_FREQ_DOMAIN_PERIPH].__rt_freq_domain_alt_fll_on = 1;
+  }
+  else
+  {
+    if(fll == HAL_FLL_CL)
+    {
+      if(__rt_freq_domain_settings[RT_FREQ_DOMAIN_CL].__rt_freq_domain_config == FREQ_DOMAIN_CLK_TREE_FLL_ALT) goto error; // cannot disable fll as it is used as clk source
+      else
+      {
+        __rt_fll_disable(fll);
+        __rt_freq_domain_settings[RT_FREQ_DOMAIN_CL].__rt_freq_domain_alt_fll_on = 0;
+      }
+    }
+    else if(fll == HAL_FLL_PER)
+    {
+      if(__rt_freq_domain_settings[RT_FREQ_DOMAIN_PERIPH].__rt_freq_domain_config == FREQ_DOMAIN_CLK_TREE_FLL_ALT) goto error; // cannot disable fll as it is used as clk source
+      else
+      {
+        __rt_fll_disable(fll);
+        __rt_freq_domain_settings[RT_FREQ_DOMAIN_PERIPH].__rt_freq_domain_alt_fll_on = 0;
+      }
+    }
+    else if(fll == HAL_FLL_SOC) goto error; // soc fll cannot be turned off at the moment
+  }
+
+  // set
+  switch(fll)
+  {
+    case HAL_FLL_CL: 
+    {
+      freq = __rt_fll_set_active_set(fll, set);
+      // update internal settings when cl fll is choosen as clk source for cl clk
+      if(__rt_freq_domain_settings[RT_FREQ_DOMAIN_CL].__rt_freq_domain_config == FREQ_DOMAIN_CLK_TREE_FLL_ALT) __rt_freq_domain_settings[RT_FREQ_DOMAIN_CL].__rt_freq_domain_freq = freq;
+      break;
+    }
+    case HAL_FLL_SOC:
+    {
+      // take care here!!
+      if(hal_fll_check_ref_fast()) hal_freq_soc_clk_tree_config_set(FREQ_DOMAIN_CLK_TREE_16M); // fast reference up and running
+      else hal_freq_soc_clk_tree_config_set(FREQ_DOMAIN_CLK_TREE_32K); // take slow reference because fast is not running properly
+
+      freq = __rt_fll_set_active_set(fll, set);
+
+      hal_freq_soc_clk_tree_config_set(FREQ_DOMAIN_CLK_TREE_FLL_SOC);  // switch back to fll_soc clock for soc_clk
+
+      // update internal settings for all clk domains which have soc fll as clk source
+      if(__rt_freq_domain_settings[RT_FREQ_DOMAIN_CL].__rt_freq_domain_config == FREQ_DOMAIN_CLK_TREE_FLL_SOC) __rt_freq_domain_settings[RT_FREQ_DOMAIN_CL].__rt_freq_domain_freq = freq; 
+      if(__rt_freq_domain_settings[RT_FREQ_DOMAIN_FC].__rt_freq_domain_config == FREQ_DOMAIN_CLK_TREE_FLL_SOC) __rt_freq_domain_settings[RT_FREQ_DOMAIN_FC].__rt_freq_domain_freq = freq; 
+      if(__rt_freq_domain_settings[RT_FREQ_DOMAIN_PERIPH].__rt_freq_domain_config == FREQ_DOMAIN_CLK_TREE_FLL_SOC) __rt_freq_domain_settings[RT_FREQ_DOMAIN_PERIPH].__rt_freq_domain_freq = freq; 
+      if(__rt_freq_domain_settings[RT_FREQ_DOMAIN_PM].__rt_freq_domain_config == FREQ_DOMAIN_CLK_TREE_FLL_SOC) __rt_freq_domain_settings[RT_FREQ_DOMAIN_PM].__rt_freq_domain_freq = freq; 
+      break;
+    }
+    case HAL_FLL_PER:
+    {
+      freq = __rt_fll_set_active_set(fll, set);
+      // update internal settings when per fll is choosen as clk source for per clk
+      if(__rt_freq_domain_settings[RT_FREQ_DOMAIN_PERIPH].__rt_freq_domain_config == FREQ_DOMAIN_CLK_TREE_FLL_ALT) __rt_freq_domain_settings[RT_FREQ_DOMAIN_PERIPH].__rt_freq_domain_freq = freq;
+      break;
+    }
+    default: goto error;
+  }
+
+  error = 0;
+
+error:
+  rt_irq_restore(irq);  
+  return error;  
+}
+


### PR DESCRIPTION
Added kernel files for freq and fll support for VivoSoC3 (in kernel/vivosoc3 folder) adapted kernel.mk for new files. Adapted kernel/cluster.c to work with vivosoc3 freq kernel. Adapted rt_freq.h according to freq and fll kernel (I rearranged the code to separate vivosoc3 stuff and the rest of the chips). Documentation of freq kernel is done as well